### PR TITLE
Change Content-MD5 calculation from hexString to base64EncodedString

### DIFF
--- a/Sources/S3Storage/S3 Signer/S3Adapter+Networking.swift
+++ b/Sources/S3Storage/S3 Signer/S3Adapter+Networking.swift
@@ -20,8 +20,7 @@ extension S3Adapter {
         var updatedHeaders = self.updateHeaders(headers, url: url, longDate: dates.long, bodyDigest: bodyDigest)
         
         if httpMethod == .PUT && payload.isBytes {
-            // TODO: Figure out why S3 would fail with this
-            updatedHeaders["Content-MD5"] = try MD5.hash(payload.bytes).hexEncodedString()
+            updatedHeaders["Content-MD5"] = try MD5.hash(payload.bytes).base64EncodedString()
         }
 
         updatedHeaders["Authorization"] = try self.generateAuthHeader(httpMethod, url: url, headers: updatedHeaders, bodyDigest: bodyDigest, dates: dates)

--- a/Sources/S3Storage/S3Adapter.swift
+++ b/Sources/S3Storage/S3Adapter.swift
@@ -86,6 +86,9 @@ extension S3Adapter {
         request.http.body = HTTPBody(data: content)
         request.http.url = url
         return try client.respond(to: request).map(to: ObjectInfo.self) { response in
+            guard response.http.status == .ok else {
+                throw S3AdapterError(identifier: "create", reason: "Couldnt not create the file.", source: .capture())
+            }
             return ObjectInfo(name: url.lastPathComponent, prefix: nil, size: nil, etag: "MD5-Hash", lastModified: Date())
         }
     }


### PR DESCRIPTION
When uploading an image the following error is returned:
```
HTTP/1.1 400 Bad Request
Content-Type: application/xml
Connection: close
x-amz-id-2: s2KGLkF7c7P8fxTtP9QBDRk9iv5CEqY66U0w0/5kdYNHSSrhPqnMdoIxqZXbzj23/hK0DzEzvso=
x-amz-request-id: 0F661FDDA96FA3FC
Server: AmazonS3
Date: Mon, 30 Apr 2018 05:43:05 GMT
content-length: 332
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidDigest</Code><Message>The Content-MD5 you specified was invalid.</Message><Content-MD5>a9500865996d8c8af4641b664ad57cc8</Content-MD5><RequestId>0F661FDDA96FA3FC</RequestId><HostId>s2KGLkF7c7P8fxTtP9QBDRk9iv5CEqY66U0w0/5kdYNHSSrhPqnMdoIxqZXbzj23/hK0DzEzvso=</HostId></Error>
```

As seen in the docs (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html), S3 expects an base64encoded MD5 hash instead of hex encoded.
```
The base64-encoded 128-bit MD5 digest of the message (without the headers) according to RFC 1864. This header can be used as a message integrity check to verify that the data is the same data that was originally sent. 
```
